### PR TITLE
[fix] Resolves #31

### DIFF
--- a/src/parser.jl
+++ b/src/parser.jl
@@ -10,7 +10,8 @@ function tokenizer(txt::String, config::ParserConfig)
     tokens = Vector{Token}()
     idx = 1
     i = 1
-    while i <= length(txt)
+
+    for i in eachindex(txt)
         if txt[i:min(nextind(txt, i, length(config.control_block[1])-1), end)] == config.control_block[1]
             push!(tokens, txt[idx:i-1])
             push!(tokens, :control_start)


### PR DESCRIPTION
As explained in #31, using the length of a string to get a character's index don't work with character of other languages such as Spanish. Because this scenario only works with 1-byte characters (English alphabet). 

So, OteraEngine returns an error when rendering templates that have 2-byte characters, such _é or ñ_ (In spanish).

## Solution:
Replace the while loop + `lenght()` with a for loop and `eachindex()` function to get the index of each character correctly :+1:  