### PR TITLE
Add |> safe filter

### DIFF
--- a/src/OteraEngine.jl
+++ b/src/OteraEngine.jl
@@ -1,7 +1,7 @@
 module OteraEngine
 
 using TOML
-import Markdown: htmlesc
+import Markdown: Markdown
 
 export Template, @filter
 

--- a/src/filter.jl
+++ b/src/filter.jl
@@ -1,4 +1,28 @@
-filters = Expr[:(e=htmlesc), :(escape=htmlesc), :(upper=uppercase), :(lower=lowercase)]
+struct SafeString
+    str::String
+end
+
+function htmlesc(str::String)
+    return Markdown.htmlesc(str)
+end
+
+function htmlesc(str::SafeString)
+    return str.str
+end
+
+function safe(str::String)
+    return SafeString(str)
+end
+
+function safe(str::SafeString   )
+    return str
+end
+
+function Base.string(str::SafeString)
+    return str
+end
+
+filters = Expr[:(e=htmlesc), :(escape=htmlesc), :(upper=uppercase), :(lower=lowercase), :(safe=safe)]
 
 """
     @filter func

--- a/src/template.jl
+++ b/src/template.jl
@@ -71,6 +71,7 @@ function define_filters(filters::Dict{String, Symbol})
         "escape" => :htmlesc,
         "upper" => :uppercase,
         "lower" => :lowercase,
+        "safe" => :safe,
     )
     for key in keys(filters)
         filters_dict[key] = filters[key]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -139,6 +139,13 @@ using Test
     end
     @test result == tmp(init=Dict("attack"=>"<script>This is injection attack</script>"))
 
+    # use |> safe filter
+    tmp = Template("safe.html")
+    open("autoescape2.html", "r") do f
+        result = read(f, String)
+    end
+    @test result == tmp(init=Dict("attack"=>"<script>This is injection attack</script>"))
+
     tmp = Template("space_control1.html")
     open("space_control2.html", "r") do f
         result = read(f, String)

--- a/test/safe.html
+++ b/test/safe.html
@@ -1,0 +1,6 @@
+<html>
+    <head><title>MyPage</title></head>
+    <body>
+        {{ attack |> safe }}
+    </body>
+</html>


### PR DESCRIPTION
This allows including literal html fragments even when autoescape is on