### PR TITLE
Add broken test for nested extends

### DIFF
--- a/test/nestedextends1.html
+++ b/test/nestedextends1.html
@@ -1,0 +1,5 @@
+{% extends "nestedextends2.html" %}
+
+{% block content2 %}
+    <p>Hello</p>
+{% endblock %}

--- a/test/nestedextends2.html
+++ b/test/nestedextends2.html
@@ -1,0 +1,6 @@
+{% extends "nestedextends3.html" %}
+
+{% block content %}
+    <h1>Title</h1>
+    {% block content2 %}{% endblock %}
+{% endblock %}

--- a/test/nestedextends3.html
+++ b/test/nestedextends3.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>Nested Extends Test</title>
+    </head>
+    <body>
+        This is the test for nested extends blocks. Here it is:
+        {% block content %}
+        {% endblock %}
+    </body>
+</html>

--- a/test/nestedextends4.html
+++ b/test/nestedextends4.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>Nested Extends Test</title>
+    </head>
+    <body>
+        This is the test for nested extends blocks. Here it is:
+        <h1>Title</h1>
+        <p>Hello</p>
+    </body>
+</html>

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -52,6 +52,13 @@ using Test
     end
     @test result == tmp()
 
+    # check nested extends block
+    tmp = Template("nestedextends1.html", config=Dict("lstrip_blocks"=>true, "trim_blocks"=>true))
+    open("extends4.html", "r") do f
+        result = read(f, String)
+    end
+    @test result == tmp()
+
     # check super block
     tmp = Template("super1.html", config=Dict("lstrip_blocks"=>true, "trim_blocks"=>true))
     open("super3.html", "r") do f


### PR DESCRIPTION
Hi! Thanks again for your work on this. I found this problem (that I can work around for now) that the template extension doesn't allow nested inheritance. This is one of the cool things about template inheritance. You can have some basic template with just the html structure for "bare" pages, then add some layout in as many levels as you like before having the content leaf.