### PR TITLE
Fix unexpected results from quote_sql without autoescaping 

### DIFF
--- a/src/template.jl
+++ b/src/template.jl
@@ -362,7 +362,7 @@ function build_renderer(elements::CodeBlockVector, autoescape::Bool)
                 if autoescape && f != htmlesc
                     push!(render.args, :(txt *= htmlesc(string($f($(Symbol(exp[1])))))))
                 else
-                    push!(render.args, :(txt *= $f(string($(Symbol(exp[1]))))))
+                    push!(render.args, :(txt *= string($f($(Symbol(exp[1]))))))
                 end
             else
                 if autoescape

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -169,6 +169,20 @@ using Test
         @test quote_sql([1, 2, 3]) == "1, 2, 3"
         @test quote_sql(true) == "TRUE"
         @test quote_sql([1, "c", true]) == "1, 'c', TRUE"
+
+        # with autoescape
+        tmp = Template("{{ sql |> quote_sql }}", path = false)
+        @test tmp(init=Dict(:sql=>false)) == "FALSE"
+        @test tmp(init=Dict(:sql=>1)) == "1"
+        @test tmp(init=Dict(:sql=>1:3)) == "1, 2, 3"
+        @test tmp(init=Dict(:sql=>"Hello")) == "&#39;Hello&#39;"
+
+        # without autoescape
+        tmp = Template("{{ sql |> quote_sql }}", path=false, config=Dict("autoescape"=>false))
+        @test tmp(init=Dict(:sql=>false)) == "FALSE"
+        @test tmp(init=Dict(:sql=>1)) == "1"
+        @test tmp(init=Dict(:sql=>1:3)) == "1, 2, 3"
+        @test tmp(init=Dict(:sql=>"Hello")) == "'Hello'"
     end
 
     @filter repeat say_twice(txt) = txt*txt


### PR DESCRIPTION
On `1.1.0` the new `quote_sql` filter produces wrong results when autoescaping is disabled in the configuration. 

```julia
julia> using OteraEngine
julia> tmp = Template("{{ x |> quote_sql }}", path=false, config=Dict("autoescape" => false))
julia> tmp(init=Dict(:x => 1))
"'1'"  # should be "1"

julia> tmp(init=Dict(:x => false))
"'false'"  # should be "FALSE"
```

This pull requests fixes the error by changing the order of function calls in `build_renderer` when autoescaping is disabled.
I also added some tests to the filters section in runtests that do not pass on `1.1.0` but will for this pull request. 
